### PR TITLE
Bump tree-sitter-htmldjango grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Fixed
+
+- Bumped tree-sitter-htmldjango grammar to fix syntax highlighting breaking when using `_()` translation function inside variable filters (e.g. `{{ val|default:_("System") }}`). See [tree-sitter-htmldjango#4](https://github.com/joshuadavidthomas/tree-sitter-htmldjango/issues/4).
+
 ## [0.2.0]
 
 ### Added

--- a/extension.toml
+++ b/extension.toml
@@ -16,4 +16,4 @@ languages = ["Django"]
 
 [grammars.htmldjango]
 repository = "https://github.com/joshuadavidthomas/tree-sitter-htmldjango"
-commit = "60771d12aee60e4ccb220548d8a485c3aa4183cf"
+commit = "2fb8a6515e75f19854bf2c4f1620d96dbc7a1e9a"


### PR DESCRIPTION
Bumps tree-sitter-htmldjango to [2fb8a65](https://github.com/joshuadavidthomas/tree-sitter-htmldjango/commit/2fb8a6515e75f19854bf2c4f1620d96dbc7a1e9a) to fix syntax highlighting breaking when using `_()` translation function inside variable filters.

Fixes https://github.com/joshuadavidthomas/tree-sitter-htmldjango/issues/4